### PR TITLE
QoL + sprintf fix

### DIFF
--- a/qclib/qclib.c
+++ b/qclib/qclib.c
@@ -144,60 +144,92 @@ void qclib_sprintf(qcvm_t *qcvm)
 	const char *fmt;
 	char c;
 	int arg;
-	static char buffer[1024];
-
+	static char buffer[1024] = {0};
+	unsigned len = 0;
 	/* get fmt string */
 	fmt = qcvm_get_parm_string(qcvm, 0);
 
-	/* loups */
+	/* loops */
 	arg = 1;
 	while ((c = *fmt++))
 	{
 		/* sanity check */
 		if (arg > qcvm_get_argc(qcvm))
+		{
 			break;
+		}
+			
 
 		/* not a format char */
 		if (c != '%')
 		{
-			sprintf(buffer, "%c", c);
+			buffer[len] = c;
+			len++;
 			continue;
 		}
 
 		/* do formatting */
 		switch ((c = *fmt++))
 		{
-			/* % */
-			case '%':
-				sprintf(buffer, "%c", c);
-				break;
-
 			/* string */
 			case 's':
-				sprintf(buffer, "%s", qcvm_get_parm_string(qcvm, arg));
-				arg++;
+				{
+					const char* str = qcvm_get_parm_string(qcvm, arg);
+					unsigned sub_len = strlen(str);
+					for (unsigned i = 0; i < sub_len; i++) {
+						buffer[len + i] = str[i];
+					}
+					len += sub_len;
+					arg++;
+				}
 				break;
 
 			/* int */
 			case 'd':
-				sprintf(buffer, "%d", qcvm_get_parm_int(qcvm, arg));
-				arg++;
+				{
+					char str[32] = {0};
+					sprintf(str, "%d", qcvm_get_parm_int(qcvm, arg));
+					unsigned sub_len = strlen(str);
+					for (unsigned i = 0; i < sub_len; i++) {
+						buffer[len + i] = str[i];
+					}
+					len += sub_len;
+					arg++;
+				}
 				break;
 
 			/* float */
 			case 'f':
-				sprintf(buffer, "%0.4f", qcvm_get_parm_float(qcvm, arg));
-				arg++;
+				{
+					char str[32] = {0};
+					sprintf(str, "%0.4f", qcvm_get_parm_float(qcvm, arg));
+					unsigned sub_len = strlen(str);
+					for (unsigned i = 0; i < sub_len; i++) {
+						buffer[len + i] = str[i];
+					}
+					len += sub_len;
+					arg++;
+				}
 				break;
 
 			/* vector */
 			case 'v':
-				v = qcvm_get_parm_vector(qcvm, arg);
-				sprintf(buffer, "%0.4f %0.4f %0.4f", v.x, v.y, v.z);
-				arg++;
+				{
+					char str[32] = {0};
+					v = qcvm_get_parm_vector(qcvm, arg);
+					sprintf(str, "%0.4f %0.4f %0.4f", v.x, v.y, v.z);
+					unsigned sub_len = strlen(str);
+					for (unsigned i = 0; i < sub_len; i++) {
+						buffer[len + i] = str[i];
+					}
+					len += sub_len;
+					arg++;
+				}
 				break;
 		}
 	}
+
+	buffer[len] = '\0';
 
 	/* return the string */
 	qcvm_return_string(qcvm, buffer);
@@ -370,6 +402,36 @@ qcvm_export_t export_substring =
 	.args[2] = {.name = "len", .type = QCVM_FLOAT}
 };
 
+void qclib_ftoi(qcvm_t* qcvm) {
+	float f = qcvm_get_parm_float(qcvm, 0);
+
+	qcvm_return_int(qcvm, (int)f);
+}
+
+qcvm_export_t export_ftoi =
+{
+	.func = qclib_ftoi,
+	.name = "ftoi",
+	.type = QCVM_INT,
+	.argc = 1,
+	.args[0] = {.name = "f", .type = QCVM_FLOAT}
+};
+
+void qclib_itof(qcvm_t* qcvm) {
+	float f = qcvm_get_parm_float(qcvm, 0);
+
+	qcvm_return_int(qcvm, (int)f);
+}
+
+qcvm_export_t export_itof =
+{
+	.func = qclib_itof,
+	.name = "itof",
+	.type = QCVM_FLOAT,
+	.argc = 1,
+	.args[0] = {.name = "i", .type = QCVM_INT}
+};
+
 /* install qclib default builtin functions */
 void qclib_install(qcvm_t *qcvm)
 {
@@ -382,4 +444,6 @@ void qclib_install(qcvm_t *qcvm)
 	qcvm_add_export(qcvm, &export_substring);
 	qcvm_add_export(qcvm, &export_vtos);
 	qcvm_add_export(qcvm, &export_ftos);
+	qcvm_add_export(qcvm, &export_ftoi);
+	qcvm_add_export(qcvm, &export_itof);
 }

--- a/qclib/qclib.c
+++ b/qclib/qclib.c
@@ -418,9 +418,9 @@ qcvm_export_t export_ftoi =
 };
 
 void qclib_itof(qcvm_t* qcvm) {
-	float f = qcvm_get_parm_float(qcvm, 0);
+	int f = qcvm_get_parm_int(qcvm, 0);
 
-	qcvm_return_int(qcvm, (int)f);
+	qcvm_return_float(qcvm, (float)f);
 }
 
 qcvm_export_t export_itof =

--- a/qclib/qclib.qc
+++ b/qclib/qclib.qc
@@ -7,5 +7,5 @@ string strcat(string s1, string s2, ...) = #0 : strcat;
 string substring(string s, float start, float len) = #0 : substring;
 string vtos(vector v) = #0 : vtos;
 string ftos(float f) = #0 : ftos;
-int ftoi(float i) = #0 : ftoi;
+int ftoi(float f) = #0 : ftoi;
 float itof(int i) = #0 : itof;

--- a/qclib/qclib.qc
+++ b/qclib/qclib.qc
@@ -7,3 +7,5 @@ string strcat(string s1, string s2, ...) = #0 : strcat;
 string substring(string s, float start, float len) = #0 : substring;
 string vtos(vector v) = #0 : vtos;
 string ftos(float f) = #0 : ftos;
+int ftoi(float i) = #0 : ftoi;
+float itof(int i) = #0 : itof;

--- a/qcvm/qcvm_bootstrap.c
+++ b/qcvm/qcvm_bootstrap.c
@@ -76,7 +76,7 @@ qcvm_t *qcvm_from_memory(void *memory, size_t size)
 	qcvm_t *qcvm;
 
 	/* allocate qcvm */
-	qcvm = malloc(sizeof(qcvm_t));
+	qcvm = calloc(1, sizeof(qcvm_t));
 	if (qcvm == NULL)
 	{
 		qcvm_set_error(QCVM_ERROR_MALLOC);

--- a/qcvm/qcvm_return.c
+++ b/qcvm/qcvm_return.c
@@ -33,6 +33,9 @@
 #include <string.h>
 #include <stdarg.h>
 
+/* include public header */
+#include "qcvm.h"
+
 /* qcvm */
 #include "qcvm_private.h"
 
@@ -49,18 +52,12 @@ void qcvm_return_entity(qcvm_t *qcvm, int entity)
 /* return a string to the previous function */
 void qcvm_return_string(qcvm_t *qcvm, const char *s)
 {
-	/* bounds check */
-	if (qcvm->tempstrings_ptr + strlen(s) + 1 > qcvm->tempstrings + TEMPSTRINGS_SIZE)
-		qcvm->tempstrings_ptr = qcvm->tempstrings;
-
 	/* sprintf */
-	sprintf(qcvm->tempstrings_ptr, "%s", s);
+	memset(qcvm->tempstrings_ptr, 0, TEMPSTRINGS_SIZE);
+	memcpy(qcvm->tempstrings_ptr, s, strlen(s));
 
 	/* return str */
 	RETURN_STRING(qcvm->tempstrings_ptr);
-
-	/* advance ptr */
-	qcvm->tempstrings_ptr += strlen(s) + 1;
 }
 
 /* return a formatted string to the previous function */


### PR DESCRIPTION
Hey! I'm embedding your QuakeC VM in a project of mine, thanks for your kind work! I needed some modifications/fixes  to make it works. This pull request is a way of giving back what I received, hehe. Feel free to add it (or not, your choice). Some other changes may appear in the future if I find anything else.

- Some memory was uninitialized, leading to strange value in the qcvm_t struct.
- The sprintf implementation was kinda weird, and wasn't working at all (I don't even know if it worked once).
- Adding a simple "user pointer" feature, to allow an exported function to retrieve any game specific data without relying on globals.
- Adding ftoi (float to integer) and itof (integer to float)

I can't get the CMake toolchain to work with my version of `fteqcc` (skill issue on my end ig), but I can confirm I tested the changes in my engine.